### PR TITLE
Remove unused fonts from layout

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,12 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="9d34ff72-d30d-4df0-98c6-c765f86fd41e" name="Default Changelist" comment="whatsapp button added">
+    <list default="true" id="9d34ff72-d30d-4df0-98c6-c765f86fd41e" name="Default Changelist" comment="footer responsive added">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/components/Footer/Footer.module.scss" beforeDir="false" afterPath="$PROJECT_DIR$/components/Footer/Footer.module.scss" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/components/WhatsAppButton/WhatsAppButton.module.scss" beforeDir="false" afterPath="$PROJECT_DIR$/components/WhatsAppButton/WhatsAppButton.module.scss" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/components/WhatsAppButton/index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/components/WhatsAppButton/index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/yarn.lock" beforeDir="false" afterPath="$PROJECT_DIR$/yarn.lock" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/styles/globals.scss" beforeDir="false" afterPath="$PROJECT_DIR$/styles/globals.scss" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -189,7 +186,7 @@
     "DefaultHtmlFileTemplate": "HTML File",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "codex/change-icon-library-to-font-awesome",
+    "git-widget-placeholder": "codex/update-headers-and-paragraph-fonts",
     "last_opened_file_path": "C:/Users/acost/WebstormProjects/teclas-web/public",
     "node.js.detected.package.eslint": "true",
     "node.js.detected.package.tslint": "true",
@@ -292,7 +289,15 @@
       <option name="project" value="LOCAL" />
       <updated>1751223739497</updated>
     </task>
-    <option name="localTasksCounter" value="6" />
+    <task id="LOCAL-00006" summary="footer responsive added">
+      <option name="closed" value="true" />
+      <created>1751227108000</created>
+      <option name="number" value="00006" />
+      <option name="presentableId" value="LOCAL-00006" />
+      <option name="project" value="LOCAL" />
+      <updated>1751227108000</updated>
+    </task>
+    <option name="localTasksCounter" value="7" />
     <servers />
   </component>
   <component name="TimeTrackingManager">
@@ -339,7 +344,8 @@
     <MESSAGE value="fix navbar" />
     <MESSAGE value="Google Analytics Tag" />
     <MESSAGE value="whatsapp button added" />
-    <option name="LAST_COMMIT_MESSAGE" value="whatsapp button added" />
+    <MESSAGE value="footer responsive added" />
+    <option name="LAST_COMMIT_MESSAGE" value="footer responsive added" />
   </component>
   <component name="editorHistoryManager">
     <entry file="file://$PROJECT_DIR$/css/bootstrap.min.css">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,21 +1,24 @@
 import type React from "react";
 import type { Metadata } from "next";
-import { Lora, Playfair_Display } from "next/font/google";
+import { Delius, Comic_Neue } from "next/font/google";
 import "../styles/globals.scss";
 import NavBar from "@/components/NavBar";
 import Footer from "@/components/Footer";
 import WhatsAppButton from "@/components/WhatsAppButton";
 import Script from "next/script";
 
-const playfair = Playfair_Display({
+
+const delius = Delius({
     subsets: ["latin"],
-    variable: "--font-playfair",
+    weight: "400",
+    variable: "--font-delius",
     display: "swap",
 });
 
-const lora = Lora({
+const comicNeue = Comic_Neue({
     subsets: ["latin"],
-    variable: "--font-lora",
+    weight: ["400"],
+    variable: "--font-comic-neue",
     display: "swap",
 });
 
@@ -53,7 +56,7 @@ export default function RootLayout({
                 }}
             />
         </head>
-        <body className={`${playfair.variable} ${lora.variable} font-serif bg-white text-gray-900`}>
+        <body className={`${delius.variable} ${comicNeue.variable} font-serif bg-white text-gray-900`}>
         <NavBar />
         <main>{children}</main>
         <WhatsAppButton />

--- a/components/NavBar/NavBar.module.scss
+++ b/components/NavBar/NavBar.module.scss
@@ -58,6 +58,7 @@
   text-decoration: none;
   color: inherit;
   transition: color 0.3s ease;
+  font-family: var(--font-delius), Arial, Helvetica, sans-serif;
 
   &:hover {
     color: var(--gold);

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -27,3 +27,16 @@ a {
   cursor: pointer;
   text-decoration: none;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-delius), Arial, Helvetica, sans-serif;
+}
+
+p {
+  font-family: var(--font-comic-neue), Arial, Helvetica, sans-serif;
+}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -40,3 +40,7 @@ h6 {
 p {
   font-family: var(--font-comic-neue), Arial, Helvetica, sans-serif;
 }
+
+button {
+  font-family: var(--font-delius), Arial, Helvetica, sans-serif;
+}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -4,6 +4,7 @@ html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
+  font-family: var(--font-comic-neue), Arial, Helvetica, sans-serif;
 }
 
 body {


### PR DESCRIPTION
## Summary
- drop Playfair and Lora fonts
- keep Delius and Comic Neue for headers and paragraphs
- ensure globals.scss ends with newline

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68619ee8c000832297b1a46a3a828a8c