### PR TITLE
Add local SEO data and new pages

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import eventJsonLd from "@/lib/seo/event";
+
+export const metadata: Metadata = {
+  title: "Eventos | TECLAS Ciudad Jard\u00edn",
+  description: "Pr\u00f3ximos eventos y talleres de piano en Ciudad Jard\u00edn, Buenos Aires."
+};
+
+export function Head() {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(eventJsonLd) }}
+    />
+  );
+}
+
+export default function EventsPage() {
+  return (
+    <div className="container my-8">
+      <h1 className="text-3xl font-bold mb-4">Pr\u00f3ximos Eventos</h1>
+      <div className="border p-4">
+        <h2 className="text-xl font-semibold mb-2">Piano Workshop in Ciudad Jard\u00edn</h2>
+        <p>01 de septiembre de 2024, 10:00 hs.</p>
+        <p>Taller intensivo de piano para todos los niveles.</p>
+        <a href="tel:+541134162288" className="text-blue-600 underline">Contactar para inscripci\u00f3n</a>
+      </div>
+    </div>
+  );
+}

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import faqJsonLd from "@/lib/seo/faq";
+
+export const metadata: Metadata = {
+  title: "Preguntas frecuentes | TECLAS Ciudad Jard\u00edn",
+  description: "Respuestas a las dudas m\u00e1s comunes sobre nuestras clases de piano en Ciudad Jard\u00edn, Buenos Aires."
+};
+
+export function Head() {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+    />
+  );
+}
+
+export default function FAQPage() {
+  return (
+    <div className="container my-8">
+      <h1 className="text-3xl font-bold mb-4">Preguntas Frecuentes</h1>
+      <div className="space-y-6">
+        <div>
+          <h2 className="font-semibold">\u00bfNecesito experiencia previa para tomar clases?</h2>
+          <p>No es necesario contar con experiencia previa, nos adaptamos a tu nivel.</p>
+        </div>
+        <div>
+          <h2 className="font-semibold">\u00bfCu\u00e1ntas clases por semana se dictan?</h2>
+          <p>Por lo general ofrecemos una clase semanal de una hora.</p>
+        </div>
+        <div>
+          <h2 className="font-semibold">\u00bfPuedo asistir a una clase de prueba?</h2>
+          <p>S\u00ed, pod\u00e9s coordinar una clase de prueba sin compromiso.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,8 +30,8 @@ const lobster = Lobster({
 });
 
 export const metadata: Metadata = {
-    title: "Teclas Ciudad Jardín",
-    description: "Domina el arte del piano con clases presenciales personalizadas",
+    title: "TECLAS - Clases de Piano en Ciudad Jardín, Buenos Aires",
+    description: "Clases de piano personalizadas en Ciudad Jardín, Buenos Aires. Domina el arte del piano con clases presenciales adaptadas a vos.",
     generator: "v0.dev",
     icons: {
         icon: "/favicon.ico",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,9 @@
-import AboutTeacher from "@/components/AboutTeacher"
-import Inscription from "@/components/Inscription"
+import AboutTeacher from "@/components/AboutTeacher";
+import Inscription from "@/components/Inscription";
 import HeroSection from "@/components/Hero";
 import AboutAcademy from "@/components/AboutAcademy";
+import type { Metadata } from "next";
+import localBusinessJsonLd from "@/lib/seo/localBusiness";
 
 export default function Home() {
     return (
@@ -10,6 +12,25 @@ export default function Home() {
             <AboutAcademy/>
             <AboutTeacher/>
             <Inscription/>
+        </>
+    );
+}
+
+export const metadata: Metadata = {
+    title: "TECLAS - Clases de Piano en Ciudad Jardín, Buenos Aires",
+    description:
+        "Clases de piano personalizadas en Ciudad Jardín, Buenos Aires. Domina el arte del piano con clases presenciales adaptadas a vos.",
+};
+
+export function Head() {
+    return (
+        <>
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{
+                    __html: JSON.stringify(localBusinessJsonLd),
+                }}
+            />
         </>
     );
 }

--- a/components/AboutAcademy/index.tsx
+++ b/components/AboutAcademy/index.tsx
@@ -46,6 +46,9 @@ export default function AboutAcademy() {
                             </p>
                         </div>
                     </div>
+                    <div className={styles.mapWrapper}>
+                        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3284.1932270987486!2d-58.5877735!3d-34.59927509999999!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x95bcb92b272dead5%3A0xd423ce89aadcbad6!2sTECLAS!5e0!3m2!1sen!2sar!4v1751302593673!5m2!1sen!2sar" width="600" height="450" style={{border:0}} allowFullScreen loading="lazy" referrerPolicy="no-referrer-when-downgrade"></iframe>
+                    </div>
                 </div>
         </section>
     );

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -18,7 +18,7 @@ export default function Footer() {
                         <div className={styles.footerLocation}>
                             <FontAwesomeIcon icon={faMapPin} className={styles.icon} />
                             <p>
-                                Ciudad Jardín Lomas del Palomar, Buenos Aires
+                                Blvd. F.i.n.c.a 61 42 Local 12, B1684 Cdad. Jardin Lomas de Palomar, Provincia de Buenos Aires
                             </p>
                         </div>
                     </div>
@@ -28,7 +28,7 @@ export default function Footer() {
                         <div className={styles.contactContent}>
                             <p>
                                 <FontAwesomeIcon icon={faPhone} className={styles.icon} />
-                                <span>(+54) 9 11 3416-2288</span>
+                                <a href="tel:+541134162288">(+54) 9 11 3416-2288</a>
                             </p>
                             <Link
                                 href="https://www.instagram.com/teclas.ciudadjardin/"

--- a/components/Hero/index.tsx
+++ b/components/Hero/index.tsx
@@ -18,10 +18,10 @@ export default function HeroSection() {
                     </div>
                     <div className={styles.heroContent}>
                         <h1 className={styles.heroTitle}>
-                            Domina el arte del piano con clases personalizadas
+                            Clases de piano en Ciudad Jardín, Buenos Aires
                         </h1>
                         <p className={styles.heroSubtitle}>
-                            Clases presenciales personalizadas diseñadas para sacar al pianista que llevas dentro.
+                            Domina el arte del piano con clases presenciales diseñadas para sacar al pianista que llevas dentro.
                         </p>
                         <Link href="https://docs.google.com/forms/d/e/1FAIpQLSenT_EzJoCuNDeRN6dQN38OdeJ8RBybZvxOkESqKQBYAObf8w/viewform?usp=dialog" className="btnPrimary">
                             Comienza hoy mismo

--- a/components/NavBar/index.tsx
+++ b/components/NavBar/index.tsx
@@ -91,6 +91,12 @@ function NavLinks({ handleSmoothScroll }: NavLinksProps) {
             <a href="#inscription" className={styles.navLink} onClick={(e) => handleSmoothScroll(e, '#inscription')}>
                 Inscripción
             </a>
+            <Link href="/events" className={styles.navLink}>
+                Eventos
+            </Link>
+            <Link href="/faq" className={styles.navLink}>
+                Preguntas Frecuentes
+            </Link>
            {/* <Link href="/resources" className={styles.navLink}>
                 Recursos
             </Link>*/}

--- a/lib/seo/event.ts
+++ b/lib/seo/event.ts
@@ -1,0 +1,32 @@
+export const eventJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Event",
+  "name": "Piano Workshop in Ciudad Jardín",
+  "startDate": "2024-09-01T10:00:00-03:00",
+  "endDate": "2024-09-01T12:00:00-03:00",
+  "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+  "eventStatus": "https://schema.org/EventScheduled",
+  "location": {
+    "@type": "Place",
+    "name": "TECLAS",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Blvd. F.i.n.c.a 61 42 Local 12",
+      "addressLocality": "Cdad. Jardin Lomas de Palomar",
+      "addressRegion": "Buenos Aires",
+      "postalCode": "B1684",
+      "addressCountry": "AR"
+    }
+  },
+  "image": "https://example.com/icon.png",
+  "description": "Taller intensivo de piano para todos los niveles.",
+  "offers": {
+    "@type": "Offer",
+    "url": "https://example.com/events/workshop",
+    "price": "0",
+    "priceCurrency": "ARS",
+    "availability": "https://schema.org/InStock"
+  }
+};
+export default eventJsonLd;
+

--- a/lib/seo/faq.ts
+++ b/lib/seo/faq.ts
@@ -1,0 +1,32 @@
+export const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Necesito experiencia previa para tomar clases?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No es necesario tener conocimientos previos, enseñamos desde nivel inicial hasta avanzado."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cuántas clases por semana se dictan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Generalmente ofrecemos una clase semanal de una hora, aunque podemos adaptarnos a otras necesidades."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Puedo asistir a una clase de prueba?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí, coordinamos clases de prueba para que conozcas nuestra metodología antes de inscribirte."
+      }
+    }
+  ]
+};
+export default faqJsonLd;
+

--- a/lib/seo/localBusiness.ts
+++ b/lib/seo/localBusiness.ts
@@ -1,0 +1,26 @@
+export const localBusinessJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  "name": "TECLAS",
+  "description": "Escuela de piano en Ciudad Jard\u00edn, Buenos Aires",
+  "telephone": "+54 11 3416-2288",
+  "url": "https://example.com",
+  "image": "https://example.com/icon.png",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "Blvd. F.i.n.c.a 61 42 Local 12",
+    "addressLocality": "Cdad. Jardin Lomas de Palomar",
+    "addressRegion": "Buenos Aires",
+    "postalCode": "B1684",
+    "addressCountry": "AR"
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": -34.5992751,
+    "longitude": -58.5877735
+  },
+  "sameAs": [
+    "https://www.instagram.com/teclas.ciudadjardin"
+  ]
+};
+export default localBusinessJsonLd;


### PR DESCRIPTION
## Summary
- update default metadata to include location
- add LocalBusiness schema and inject on homepage
- update hero text with location
- show full address and clickable phone in footer
- embed Google map in academy section
- add FAQ and Events pages with structured data
- move eventJsonLd and faqJsonLd to the seo folder for reuse
- add links to FAQ and Events in navbar

## Testing
- `npm install` *(fails: dependency conflicts)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c2c6c2c08322a808718880347acc