### PR TITLE
Add central metadata index

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,10 +1,8 @@
-import type { Metadata } from "next";
 import eventJsonLd from "@/lib/seo/event";
+import { eventsMetadata } from "@/lib/metadata";
 
-export const metadata: Metadata = {
-  title: "Eventos | TECLAS Ciudad Jardín",
-  description: "Próximos eventos y talleres de piano en Ciudad Jardín, Buenos Aires."
-};
+export { eventsMetadata as metadata };
+
 
 export function Head() {
   return (

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,10 +1,8 @@
-import type { Metadata } from "next";
 import faqJsonLd from "@/lib/seo/faq";
+import { faqMetadata } from "@/lib/metadata";
 
-export const metadata: Metadata = {
-  title: "Preguntas frecuentes | TECLAS Ciudad Jardín",
-  description: "Respuestas a las dudas más comunes sobre nuestras clases de piano en Ciudad Jardín, Buenos Aires."
-};
+export { faqMetadata as metadata };
+
 
 export function Head() {
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,10 +31,31 @@ const lobster = Lobster({
 
 export const metadata: Metadata = {
     title: "TECLAS - Clases de Piano en Ciudad Jardín, Buenos Aires",
-    description: "Clases de piano personalizadas en Ciudad Jardín, Buenos Aires. Domina el arte del piano con clases presenciales adaptadas a vos.",
+    description:
+        "Clases de piano personalizadas en Ciudad Jardín, Buenos Aires. Domina el arte del piano con clases presenciales adaptadas a vos.",
     generator: "v0.dev",
     icons: {
         icon: "/favicon.ico",
+    },
+    alternates: {
+        canonical: "https://teclasciudadjardin.com.ar/",
+    },
+    robots: {
+        index: true,
+        follow: true,
+    },
+    openGraph: {
+        type: "website",
+        url: "https://teclasciudadjardin.com.ar/",
+        title: "TECLAS - Clases de Piano en Ciudad Jardín, Buenos Aires",
+        description:
+            "Clases de piano personalizadas en Ciudad Jardín, Buenos Aires. Domina el arte del piano con clases presenciales adaptadas a vos.",
+        siteName: "TECLAS",
+        images: [
+            {
+                url: "/teclas.jpg",
+            },
+        ],
     },
 };
 
@@ -47,6 +68,8 @@ export default function RootLayout({
         <html lang="en">
         <head>
             <link rel="icon" href="/favicon.ico" />
+            <meta name="robots" content="index, follow" />
+            <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
 
             {/* Google Analytics */}
             <Script

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,35 +2,29 @@ import AboutTeacher from "@/components/AboutTeacher";
 import Inscription from "@/components/Inscription";
 import HeroSection from "@/components/Hero";
 import AboutAcademy from "@/components/AboutAcademy";
-import type { Metadata } from "next";
 import localBusinessJsonLd from "@/lib/seo/localBusiness";
+import { homeMetadata } from "@/lib/metadata";
+
+export { homeMetadata as metadata };
 
 export default function Home() {
-    return (
-        <>
-            <HeroSection/>
-            <AboutAcademy/>
-            <AboutTeacher/>
-            <Inscription/>
-        </>
-    );
+  return (
+    <>
+      <HeroSection />
+      <AboutAcademy />
+      <AboutTeacher />
+      <Inscription />
+    </>
+  );
 }
 
-export const metadata: Metadata = {
-    title: "TECLAS - Clases de Piano en Ciudad Jardín, Buenos Aires",
-    description:
-        "Clases de piano personalizadas en Ciudad Jardín, Buenos Aires. Domina el arte del piano con clases presenciales adaptadas a vos.",
-};
-
 export function Head() {
-    return (
-        <>
-            <script
-                type="application/ld+json"
-                dangerouslySetInnerHTML={{
-                    __html: JSON.stringify(localBusinessJsonLd),
-                }}
-            />
-        </>
-    );
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessJsonLd) }}
+      />
+    </>
+  );
 }

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -8,6 +8,10 @@ import {
   faBookOpen,
 } from "@fortawesome/free-solid-svg-icons"
 
+import { resourcesMetadata } from "@/lib/metadata";
+
+export { resourcesMetadata as metadata };
+
 export default function ResourcesPage() {
   return (
     <>

--- a/lib/metadata/index.tsx
+++ b/lib/metadata/index.tsx
@@ -1,0 +1,109 @@
+import type { Metadata } from "next";
+
+export const homeMetadata: Metadata = {
+  title: "TECLAS - Clases de Piano en Ciudad Jardín, Buenos Aires",
+  description:
+    "Clases de piano personalizadas en Ciudad Jardín, Buenos Aires. Domina el arte del piano con clases presenciales adaptadas a vos.",
+  alternates: {
+    canonical: "https://teclasciudadjardin.com.ar/",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  openGraph: {
+    type: "website",
+    url: "https://teclasciudadjardin.com.ar/",
+    title: "TECLAS - Clases de Piano en Ciudad Jardín, Buenos Aires",
+    description:
+      "Clases de piano personalizadas en Ciudad Jardín, Buenos Aires. Domina el arte del piano con clases presenciales adaptadas a vos.",
+    siteName: "TECLAS",
+    images: [
+      {
+        url: "/teclas.jpg",
+      },
+    ],
+  },
+};
+
+export const eventsMetadata: Metadata = {
+  title: "Eventos | TECLAS Ciudad Jardín",
+  description: "Próximos eventos y talleres de piano en Ciudad Jardín, Buenos Aires.",
+  alternates: {
+    canonical: "https://teclasciudadjardin.com.ar/events",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  openGraph: {
+    type: "website",
+    url: "https://teclasciudadjardin.com.ar/events",
+    title: "Eventos | TECLAS Ciudad Jardín",
+    description:
+      "Próximos eventos y talleres de piano en Ciudad Jardín, Buenos Aires.",
+    siteName: "TECLAS",
+    images: [
+      {
+        url: "/teclas.jpg",
+      },
+    ],
+  },
+};
+
+export const faqMetadata: Metadata = {
+  title: "Preguntas frecuentes | TECLAS Ciudad Jardín",
+  description:
+    "Respuestas a las dudas más comunes sobre nuestras clases de piano en Ciudad Jardín, Buenos Aires.",
+  alternates: {
+    canonical: "https://teclasciudadjardin.com.ar/faq",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  openGraph: {
+    type: "website",
+    url: "https://teclasciudadjardin.com.ar/faq",
+    title: "Preguntas frecuentes | TECLAS Ciudad Jardín",
+    description:
+      "Respuestas a las dudas más comunes sobre nuestras clases de piano en Ciudad Jardín, Buenos Aires.",
+    siteName: "TECLAS",
+    images: [
+      {
+        url: "/teclas.jpg",
+      },
+    ],
+  },
+};
+
+export const resourcesMetadata: Metadata = {
+  title: "Learning Resources | TECLAS Ciudad Jardín",
+  description: "Material de aprendizaje para mejorar tu práctica de piano.",
+  alternates: {
+    canonical: "https://teclasciudadjardin.com.ar/resources",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  openGraph: {
+    type: "website",
+    url: "https://teclasciudadjardin.com.ar/resources",
+    title: "Learning Resources | TECLAS Ciudad Jardín",
+    description: "Material de aprendizaje para mejorar tu práctica de piano.",
+    siteName: "TECLAS",
+    images: [
+      {
+        url: "/teclas.jpg",
+      },
+    ],
+  },
+};
+
+export default {
+  homeMetadata,
+  eventsMetadata,
+  faqMetadata,
+  resourcesMetadata,
+};

--- a/lib/seo/event.ts
+++ b/lib/seo/event.ts
@@ -18,11 +18,11 @@ export const eventJsonLd = {
       "addressCountry": "AR"
     }
   },
-  "image": "https://example.com/icon.png",
+  "image": "https://teclasciudadjardin.com.ar/teclas.jpg",
   "description": "Taller intensivo de piano para todos los niveles.",
   "offers": {
     "@type": "Offer",
-    "url": "https://example.com/events/workshop",
+    "url": "https://teclasciudadjardin.com.ar/events/workshop",
     "price": "0",
     "priceCurrency": "ARS",
     "availability": "https://schema.org/InStock"

--- a/lib/seo/localBusiness.ts
+++ b/lib/seo/localBusiness.ts
@@ -4,8 +4,8 @@ export const localBusinessJsonLd = {
   "name": "TECLAS",
   "description": "Escuela de piano en Ciudad Jardín, Buenos Aires",
   "telephone": "+54 11 3416-2288",
-  "url": "https://example.com",
-  "image": "https://example.com/icon.png",
+  "url": "https://teclasciudadjardin.com.ar",
+  "image": "https://teclasciudadjardin.com.ar/teclas.jpg",
   "address": {
     "@type": "PostalAddress",
     "streetAddress": "Blvd. F.i.n.c.a 61 42 Local 12",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://teclasciudadjardin.com.ar/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://teclasciudadjardin.com.ar/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://teclasciudadjardin.com.ar/events</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://teclasciudadjardin.com.ar/faq</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://teclasciudadjardin.com.ar/resources</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- centralize page metadata into `lib/metadata/index.tsx`
- update pages to import their metadata from the new file

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862db35d73c8322baaa3a1088ed7993